### PR TITLE
Introduce gh action to release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish Extension
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+        if: hashFiles('package-lock.json') != ''
+
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com

--- a/README.md
+++ b/README.md
@@ -26,3 +26,6 @@ You can install this theme through the Visual Studio Code [Marketplace](https://
 ![media](https://imgur.com/QFHNKq8.png)
 ![media](https://imgur.com/u6Opu0S.png)
 
+## License
+
+This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "email": "george.aidonidis@gmail.com",
     "url": "https://iamgeorge.dev"
   },
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/george-aidonidis/vscode-one-dark-ocean/issues",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add a GitHub Actions workflow to publish the extension on release, bump version to 0.3.0, and add a README License section.
> 
> - **CI/CD**:
>   - Add GitHub Actions workflow `/.github/workflows/publish.yml` to publish the VS Code extension to the Marketplace on release or manual dispatch (Node 20 setup, optional npm install, uses `HaaLeo/publish-vscode-extension` with `VS_MARKETPLACE_TOKEN`).
> - **Package**:
>   - Bump `package.json` version to `0.3.0`.
> - **Docs**:
>   - Add License section to `README.md` referencing `LICENSE.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f25f55f10f9f3942fa24116ba7e79d10044abd7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->